### PR TITLE
Fixed bug which caused an buffer underflow

### DIFF
--- a/Master/Itho/CC1101.cpp
+++ b/Master/Itho/CC1101.cpp
@@ -218,7 +218,7 @@ bool CC1101::sendData(CC1101Packet *packet)
 		while (index < packet->length)
 		{
 			//check if there is free space in the fifo
-			while ((txStatus = (readRegisterWithSyncProblem(CC1101_TXBYTES, CC1101_STATUS_REGISTER) & CC1101_BITS_RX_BYTES_IN_FIFO)) > (CC1101_DATA_LEN - 2));
+			while ((txStatus = (readRegister(CC1101_TXBYTES | CC1101_STATUS_REGISTER) & CC1101_BITS_RX_BYTES_IN_FIFO)) > (CC1101_DATA_LEN – 2));
 			
 			//calculate how many bytes we can send
 			length = (CC1101_DATA_LEN - txStatus);


### PR DESCRIPTION
When sending a message larger than the CC1101 buffer size (64 bytes), the send method would poll the queue length to determine when more bytes could be added. Because the value being polled would keep on changing (because bytes are being transmitted), the method readRegisterWithSyncProblem would wait until the buffer was empty, because only then two reads would return the same value (64).
Thanks to JFDB for finding and fixing this bug: http://www.progz.nl/blog/index.php/2015/05/reverse-engineering-remote-itho-cve-eco-rft-part-6/#comment-223
