### PR TITLE
Modifications to CC1101.cpp and .h

### DIFF
--- a/Master/Itho/CC1101.h
+++ b/Master/Itho/CC1101.h
@@ -196,6 +196,7 @@ class CC1101
 		
 	protected:
 		uint8_t readRegister(uint8_t address);
+		uint8_t readRegisterMedian3(uint8_t address);
 		uint8_t readRegisterWithSyncProblem(uint8_t address, uint8_t registerType);
 		
 		void reset();


### PR DESCRIPTION
I implemented a readregister function that returns the median of 3 values.
readRegisterMedian3
This should reduce significantly the probability that incorrect values are read from a register, and at the same time should be (somewhat) save for reading e.g., the TX_BUFFER register that is continuously updated. It should be tolerant to reading no more than one incorrect value out of three.
Updated the send Data subroutine with this change, and added jumping put of the subroutine in case of a TXFIFO_UNDERFLOW
