### PR TITLE
Added messaging in case of TXFIFO_UNDERFLOW

### DIFF
--- a/Master/Itho/CC1101.cpp
+++ b/Master/Itho/CC1101.cpp
@@ -254,7 +254,11 @@ bool CC1101::sendData(CC1101Packet *packet)
 	}
 
 	//wait until transmission is finished (TXOFF_MODE is expected to be set to 0/IDLE or TXFIFO_UNDERFLOW)
-	do  MarcState = (readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER) & CC1101_BITS_MARCSTATE);
+	do
+	{
+		MarcState = (readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER) & CC1101_BITS_MARCSTATE);
+		if (MarcState == CC1101_MARCSTATE_TXFIFO_UNDERFLOW) debug.serOut("TXFIFO_UNDERFLOW occured in sendData() \n");
+	}
   	while((MarcState != CC1101_MARCSTATE_IDLE) && (MarcState != CC1101_MARCSTATE_TXFIFO_UNDERFLOW));
 }
 


### PR DESCRIPTION
Added a message "TXFIFO_UNDERFLOW occured in sendData()" to facilitate debugging
